### PR TITLE
Draft: Add initial support for Qwen3 embedding models

### DIFF
--- a/py_backend/main.py
+++ b/py_backend/main.py
@@ -849,6 +849,12 @@ if LIGHTRAG_AVAILABLE:
                 embedding_dim = 768
             elif 'bge-m3' in embedding_model_name:
                 embedding_dim = 1024
+            elif "qwen3-embedding-0.6b" in embedding_model_name.lower():
+                embedding_dim = 1024
+            elif "qwen3-embedding-4b" in embedding_model_name.lower():
+                embedding_dim = 2560
+            elif "qwen3-embedding-8b" in embedding_model_name.lower():
+                embedding_dim = 4096
             
             logger.info(f"Using embedding dimension: {embedding_dim}")
             


### PR DESCRIPTION
## Summary
This PR introduces **initial support for Qwen3 embedding models** with the following dimensions:
- qwen3-embedding-0.6b → 1024
- qwen3-embedding-4b → 2560
- qwen3-embedding-8b → 4096

The embedding dimension is currently determined via:
```python
elif "qwen3-embedding-0.6b" in embedding_model_name.lower():
    embedding_dim = embedding_provider_config.get("output_dim", 1024)

Related Issue
Related to: Discord discussion on Qwen/Qwen3 Embedding support (Dimension: 2560)

Changes Introduced
Added conditional checks in embedding initialization:

python
elif "qwen3-embedding-0.6b" in embedding_model_name.lower():
    embedding_dim = embedding_provider_config.get("output_dim", 1024)
elif "qwen3-embedding-4b" in embedding_model_name.lower():
    embedding_dim = embedding_provider_config.get("output_dim", 2560)
elif "qwen3-embedding-8b" in embedding_model_name.lower():
    embedding_dim = embedding_provider_config.get("output_dim", 4096)

Issue Summary
Attempting to add support for Qwen3 embedding models results in an IndexError during document processing in the LightRAG system.

Error Details
pgsql
複製程式碼
Exception: IndexError: index 8 is out of bounds for axis 0 with size 6
File "/usr/local/lib/python3.11/site-packages/lightrag/lightrag.py", line 1003, in process_document
File "/usr/local/lib/python3.11/site-packages/lightrag/kg/nano_vector_db_impl.py", line 116, in upsert
File "/usr/local/lib/python3.11/site-packages/nano_vectordb/dbs.py", line 100, in upsert
    self.__storage["matrix"][i] = update_d[f_VECTOR].astype(Float)

Root Cause
The vector database storage matrix is initialized with a fixed dimension based on the first embedding configuration (e.g. size 6).
When switching to a different embedding model (e.g. 2560 or 4096 dimensions), the storage is not resized or cleared, leading to out-of-bounds errors.

Impact
Prevents addition of Qwen3 embedding support.

Blocks document processing when switching between different embedding models in existing notebooks.

Suggested Resolution (Open for Discussion)

The system should detect embedding model changes and either:

1.Clear vector storage when switching models with different dimensions

2.Implement dynamic matrix resizing in nano_vectordb

3.Add validation to ensure storage compatibility before upsert operations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for three additional Qwen3 embedding models with automatic dimension detection and case-insensitive model name handling: 0.6B (1024), 4B (2560), 8B (4096). This broadens model compatibility and removes the need for manual dimension configuration. Existing models remain unaffected, and selection logic stays consistent, ensuring backwards compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->